### PR TITLE
console.logを色付きで出力する処理の最適化

### DIFF
--- a/index.js
+++ b/index.js
@@ -422,7 +422,7 @@ function copyFiles(files,options,callback) {
  * @param color
  */
 function echoLog(label,text,color) {
-    var defaultColor = '\u001b[30m'; //black
+    var defaultColor = '\u001b[0m'; //console's defaultColor
     var colorCode = defaultColor;
     switch(color) {
         case 'red':


### PR DESCRIPTION
コンソールの背景色を黒にしていると実行後に文字が見えなくなるため、defaultColorの値を初期状態へリセットする値「0m」に書き換えました。
