### PR TITLE
fix: 属性ラベル名の例示を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,18 +171,18 @@ Only 1 comment block in a file.
 ### Section - セクション
 
 Section of style guide.
-'@' means attribute of this section. (ex. @duplicated @todo)
+'@' means attribute of this section. (ex. @deprecated @todo)
 
 各スタイルごとに記述します。  
-@をつけるとこのセクションに属性ラベルをつけることができます（例: @非推奨, $todo）
-	
+@をつけるとこのセクションに属性ラベルをつけることができます（例: @非推奨, @todo）
+
 	/*
 	#styleguide
 	style title
 
 	style comment.
 
-	@depulicated
+	@deprecated
 	@非推奨
 	@todo
 	@your-attribute

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var FrontNote = require('frontnote');
 var note = new FrontNote({
 	out: './docs'
 });
-note.render('path/**/*.css').subscribe(function {
+note.render('path/**/*.css').subscribe(function() {
 	//callback
 });
 ```


### PR DESCRIPTION
ReadmeのSectionの属性ラベルについて、例示部分の英語に誤記が見られましたのでPRを送ります。
よろしくお願いします。

下記PRのやりとりも参照いただければと。
- https://github.com/frontainer/frontnote/pull/9

## 変更点
- 属性ラベル名として例示されていた単語を「非推奨」の英訳である「deprecated」の正しいつづりに修正した。
- todo横の$マークを@に修正した。
- 使い方（Usage）のコード例のfunction後のカッコ抜けの修正。